### PR TITLE
FEAT: examples, notes, adopters, contributors

### DIFF
--- a/SMARTCITIES/AnonymousId/ADOPTERS.yaml
+++ b/SMARTCITIES/AnonymousId/ADOPTERS.yaml
@@ -1,0 +1,10 @@
+description: This is a compilation list of the current adopters of the data model [Data model] of the Subject [Subject].  All fields are non mandatory. More info at https://smart-data-models.github.io/data-models/templates/dataModel/CURRENT_ADOPTERS.yaml
+currentAdopters:
+-
+ adopter: 
+ description: This is a compilation list of the current adopters of the data model AnonymousId of the Subject incubated/SMARTCITIES
+ mail: contacto@purpleblob.net
+ organization: Purple Blob S.L.
+ project: Argus
+ comments: 
+ startDate: 2022-09-19

--- a/SMARTCITIES/AnonymousId/CONTIBUTORS.yaml
+++ b/SMARTCITIES/AnonymousId/CONTIBUTORS.yaml
@@ -1,0 +1,32 @@
+description: This is a compilation list of all CONTRIBUTORS across different objects (data models) alphabetically ordered. All fields are non mandatory
+contributors:
+- name: Alberto
+  surname: Abella
+  mail: alberto.abella@fiware.org
+  organization: FIWARE Foundation
+  project: 
+  comments: 
+  year: 2022
+- name: Gorka
+  surname: Garcia
+  mail: ggarcia@purpleblob.net
+  organization: Purple Blob
+  project: 
+  comments: 
+  year: 2022
+- name: Iñigo 
+  surname: Ruiz
+  mail: iruiz@purpleblob.net
+  organization: Purple Blob
+  project: 
+  comments: 
+  year: 2022
+- name: Jone Begoña
+  surname: Ibarzabal
+  mail: jibarzabal@purpleblob.net
+  organization: Purple Blob
+  project: 
+  comments: 
+  year: 2022
+
+

--- a/SMARTCITIES/AnonymousId/examples/example-normalized.json
+++ b/SMARTCITIES/AnonymousId/examples/example-normalized.json
@@ -1,0 +1,41 @@
+{
+    "anonymized_id": {
+        "type": "Text",
+        "value": "D20220AC3478565F"
+    },
+    "type": "AnonymousId",
+    "orig": {
+        "type": "Text",
+        "value": "City hall"
+    },
+    "dest": {
+        "type": "Text",
+        "value": "Library"
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -2.783954,
+                43.034955
+            ]
+        }
+    },
+    "date": {
+        "type": "DateTime",
+        "value": "2022-09-05T08:25:35.00Z"
+    },
+    "algorithm": {
+        "type": "Text",
+        "value": "SHA1"
+    },
+    "dateCreated": {
+        "type": "DateTime",
+        "value": "2022-09-05T09:25:35.00Z"
+    },
+    "dateModified": {
+        "type": "DateTime",
+        "value": "2022-09-12T09:25:35.00Z"
+    }
+}

--- a/SMARTCITIES/AnonymousId/examples/example-normalized.jsonld
+++ b/SMARTCITIES/AnonymousId/examples/example-normalized.jsonld
@@ -1,0 +1,21 @@
+{
+    "anonymized_id": "D20220AC3478565F",
+    "type": "AnonymousId",
+    "date": "2022-09-05T08:25:35.00Z",
+    "orig": "City hall",
+    "dest": "Library",
+    "source": "People Monitoring",
+    "algorithm": "SHA1",
+    "dateCreated": "2022-09-05T09:25:35.00Z",
+    "dateModified": "2022-09-12T09:25:35.00Z",
+    "location": {
+        "type": "Point",
+        "coordinates": [
+            -2.783954,
+            43.034955
+        ]
+    },
+    "@context": [
+        "https://smartdatamodels.org/context.jsonld"
+    ]
+}

--- a/SMARTCITIES/AnonymousId/examples/example.json
+++ b/SMARTCITIES/AnonymousId/examples/example.json
@@ -1,0 +1,18 @@
+{
+    "anonymized_id": "D20220AC3478565F",
+    "type": "AnonymousId",
+    "date": "2022-09-05T08:25:35.00Z",
+    "orig": "City hall",
+    "dest": "Library",
+    "source": "People Monitoring",
+    "algorithm": "SHA1",
+    "dateCreated": "2022-09-05T09:25:35.00Z",
+    "dateModified": "2022-09-12T09:25:35.00Z",
+    "location": {
+        "type": "Point",
+        "coordinates": [
+            -2.783954,
+            43.034955
+        ]
+    }
+}

--- a/SMARTCITIES/AnonymousId/examples/example.jsonld
+++ b/SMARTCITIES/AnonymousId/examples/example.jsonld
@@ -1,0 +1,44 @@
+{
+    "anonymized_id": {
+        "type": "Text",
+        "value": "D20220AC3478565F"
+    },
+    "type": "AnonymousId",
+    "orig": {
+        "type": "Text",
+        "value": "City hall"
+    },
+    "dest": {
+        "type": "Text",
+        "value": "Library"
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                -2.783954,
+                43.034955
+            ]
+        }
+    },
+    "date": {
+        "type": "DateTime",
+        "value": "2022-09-05T08:25:35.00Z"
+    },
+    "algorithm": {
+        "type": "Text",
+        "value": "SHA1"
+    },
+    "dateCreated": {
+        "type": "DateTime",
+        "value": "2022-09-05T09:25:35.00Z"
+    },
+    "dateModified": {
+        "type": "DateTime",
+        "value": "2022-09-12T09:25:35.00Z"
+    },
+    "@context": [
+        "https://smartdatamodels.org/context.jsonld"
+    ]
+}

--- a/SMARTCITIES/AnonymousId/notes.yaml
+++ b/SMARTCITIES/AnonymousId/notes.yaml
@@ -1,0 +1,8 @@
+notesHeader:
+  notes appearing at the beginning of the spec
+notesMiddle:
+  notes appearing in the middle of the spec
+notesFooter:
+  notes appearing in the footer of the spec
+notesReadme:
+  notes appearing in the beginning of the README.md at the root of the data model directory

--- a/SMARTCITIES/AnonymousId/schema.json
+++ b/SMARTCITIES/AnonymousId/schema.json
@@ -1,152 +1,57 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "$schemaVersion": "0.0.1",
-  "$id": "https://github.com/smart-data-models/incubated/tree/master/SMARTCITIES/AnonymousId",
-  "title": "Anonymous Id",
-  "modelTags": "",
-  "description": "Anonymized identifier for flow monitoring. Includes an origin and destiny property to map its path.",
-  "type": "object",
-  "required": [
-    "anonymized_id",
-    "type"
-  ],
-  "definitions": {
-    "GSMA-Commons": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "$ref": "#/definitions/EntityIdentifierType"
-        },
-        "dateCreated": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Property. Entity creation timestamp. This will usually be allocated by the storage platform."
-        },
-        "dateModified": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Property. Timestamp of the last modification of the entity. This will usually be allocated by the storage platform."
-        },
-        "source": {
-          "type": "string",
-          "description": "Property. A sequence of characters giving the original source of the entity data as a URL. Recommended to be the fully qualified domain name of the source provider, or the URL to the source object."
-        },
-        "name": {
-          "type": "string",
-          "description": "Property. The name of this item."
-        },
-        "alternateName": {
-          "type": "string",
-          "description": "Property. An alternative name for this item"
-        },
-        "description": {
-          "type": "string",
-          "description": "Property. A description of this item"
-        },
-        "dataProvider": {
-          "type": "string",
-          "description": "Property. A sequence of characters identifying the provider of the harmonised data entity."
-        },
-        "owner": {
-          "type": "array",
-          "description": "Property. A List containing a JSON encoded sequence of characters referencing the unique Ids of the owner(s)",
-          "items": {
-            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/EntityIdentifierType"
-          }
-        },
-        "seeAlso": {
-          "oneOf": [
-            {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string",
-                "format": "uri"
-              }
-            },
-            {
-              "type": "string",
-              "format": "uri"
-            }
-          ],
-          "description": "Property. list of uri pointing to additional resources about the item"
-        }
-      }
-    },
-    "EntityIdentifier": {
-      "allOf": [
+    "$schema": "http://json-schema.org/schema",
+    "$schemaVersion": "0.0.1",
+    "$id": "https://github.com/smart-data-models/incubated/tree/master/SMARTCITIES/AnonymousId",
+    "title": "Anonymous Id",
+    "modelTags": "",
+    "description": "Anonymized identifier for flow monitoring. Includes an origin and destiny property to map its path.",
+    "type": "object",
+    "required": [
+        "anonymized_id",
+        "type"
+    ],
+    "allOf": [
         {
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "AnonymousId"
-              ],
-              "description": "Property. NGSI entity type. It has to be AnonymousId"
-            },
-            "date": {
-              "type": "string",
-              "format": "date-time",
-              "description": "Property. Date of the detected anonymous identifier."
-            },
-            "orig": {
-              "type": "string",
-              "description": "String value of origin id, last entity where the anonymous id was detected."
-            },
-            "dest": {
-              "type": "string",
-              "description": "String value of destination id, actual entity where the anonymous id was detected."
-            },
-            "anonymized_id": {
-              "type": "string",
-              "description": "Anonymized identifier"
-            },
-            "source": {
-              "type": "string",
-              "description": "String value of source of this AnonymousId, eg. (ALPR, People Monitoring, Face Recognition, etc...)"
-            },
-            "algorithm": {
-              "type": "string",
-              "description": "Name of the algorithm used to anonymize the Id"
-            }
-          },
-          "location": {
-            "type": "object",
+            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons"
+        },
+        {
+            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
+        },
+        {
             "properties": {
-              "title": "GeoJSON Point",
-              "type": "object",
-              "required": [
-                "type",
-                "coordinates"
-              ],
-              "description": "Geoproperty. Geojson reference to the item. Point",
-              "properties": {
                 "type": {
-                  "type": "string",
-                  "enum": [
-                    "Point"
-                  ]
+                    "type": "string",
+                    "enum": [
+                        "AnonymousId"
+                    ],
+                    "description": "Property. NGSI entity type. It has to be AnonymousId"
                 },
-                "coordinates": {
-                  "type": "array",
-                  "minItems": 2,
-                  "items": {
-                    "type": "number"
-                  }
+                "date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Property. Date of the detected anonymous identifier."
                 },
-                "bbox": {
-                  "type": "array",
-                  "minItems": 4,
-                  "items": {
-                    "type": "number"
-                  }
+                "orig": {
+                    "type": "string",
+                    "description": "String value of origin id, last entity where the anonymous id was detected."
+                },
+                "dest": {
+                    "type": "string",
+                    "description": "String value of destination id, actual entity where the anonymous id was detected."
+                },
+                "anonymized_id": {
+                    "type": "string",
+                    "description": "Anonymized identifier"
+                },
+                "source": {
+                    "type": "string",
+                    "description": "String value of source of this AnonymousId, eg. (ALPR, People Monitoring, Face Recognition, etc...)"
+                },
+                "algorithm": {
+                    "type": "string",
+                    "description": "Name of the algorithm used to anonymize the Id"
                 }
-              }
-            },
-            "description": "Geoproperty. Geojson reference to the item. It is a Point."
-          }
+            }
         }
-      ]
-    }
-  }
+    ]
 }


### PR DESCRIPTION
To avoid repeating code, I have deleted the code referring to Location-Commons and GSMA-Commons from the schema and added the link to the two codes using $ref.
I have added examples based on the main schema.
I have added the files for: contributors, notes and adopters.