### PR TITLE
add "tractionBatteryCapacity" property (VehicleModel)

### DIFF
--- a/OS2GPSConnector/CONTRIBUTORS.yaml
+++ b/OS2GPSConnector/CONTRIBUTORS.yaml
@@ -1,0 +1,9 @@
+description: This is a compilation list of all CONTRIBUTORS across different objects (data models) alphabetically ordered. All fields are non mandatory
+contributors:
+  - name:
+    surname:
+    mail: os2fleetoptimiser@os2.eu
+    organization: OS2.eu
+    project: OS2 GPS-Connector
+    comments: Project funded by OS2 for danish municipalities.
+    year: 2025

--- a/OS2GPSConnector/VehicleModel/ADOPTERS.yaml
+++ b/OS2GPSConnector/VehicleModel/ADOPTERS.yaml
@@ -1,0 +1,10 @@
+description: This is a compilation list of the current adopters of the data model VehicleModel of the Subject dataModel.Transportation.  All fields are non mandatory. More info at https://smart-data-models.github.io/data-models/templates/dataModel/CURRENT_ADOPTERS.yaml
+currentAdopters:
+-
+ adopter: OS2 GPS-Connector
+ description: Open source project for danish municipalities to collect GPS data for analysis and optimisation of their fleets
+ mail: os2fleetoptimiser@os2.eu
+ organization: https://www.os2.eu/
+ project: https://github.com/OS2sandbox/gps-connector
+ comments: Storing additional meta-data for vehicle models, such as 'tractionBatteryCapacity', allows further optimisation by calculating range for BEV.
+ startDate:

--- a/OS2GPSConnector/VehicleModel/examples/example-normalized.json
+++ b/OS2GPSConnector/VehicleModel/examples/example-normalized.json
@@ -1,0 +1,36 @@
+{
+  "id": "vehiclemodel:buzz",
+  "type": "VehicleModel",
+  "name": {
+    "type": "Text",
+    "value": "VW-IDBuzz"
+  },
+  "brandName": {
+    "type": "Text",
+    "value": "Volkswagen"
+  },
+  "modelName": {
+    "type": "Text",
+    "value": "ID. Buzz"
+  },
+  "manufacturerName": {
+    "type": "Text",
+    "value": "Volkswagen"
+  },
+  "vehicleType": {
+    "type": "Text",
+    "value": "car"
+  },
+  "fuelType": {
+    "type": "Text",
+    "value": "electric"
+  },
+  "fuelConsumption": {
+    "type": "Number",
+    "value": 20.7
+  },
+  "tractionBatteryCapacity": {
+    "type": "Number",
+    "value": 79
+  }
+}

--- a/OS2GPSConnector/VehicleModel/examples/example-normalized.jsonld
+++ b/OS2GPSConnector/VehicleModel/examples/example-normalized.jsonld
@@ -1,0 +1,40 @@
+{
+    "id": "urn:ngsi-ld:VehicleModel:vehiclemodel:buzz",
+    "type": "VehicleModel",
+    "name": {
+        "type": "Property",
+        "value": "VW-IDBuzz"
+    },
+    "brandName": {
+        "type": "Property",
+        "value": "Volkswagen"
+    },
+    "modelName": {
+        "type": "Property",
+        "value": "ID. Buzz"
+    },
+    "manufacturerName": {
+        "type": "Property",
+        "value": "Volkswagen"
+    },
+    "vehicleType": {
+        "type": "Property",
+        "value": "car"
+    },
+    "fuelType": {
+        "type": "Property",
+        "value": "electric"
+    },
+    "fuelConsumption": {
+        "type": "Property",
+        "value": 20.7
+    },
+    "tractionBatteryCapacity": {
+        "type": "Property",
+        "value": 79
+    },
+    "@context": [
+        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+        "https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld"
+    ]
+}

--- a/OS2GPSConnector/VehicleModel/examples/example.json
+++ b/OS2GPSConnector/VehicleModel/examples/example.json
@@ -1,0 +1,12 @@
+{
+  "id": "vehiclemodel:buzz",
+  "type": "VehicleModel",
+  "name": "VW-IDBuzz",
+  "brandName": "Volkswagen",
+  "modelName": "ID. Buzz",
+  "manufacturerName": "Volkswagen",
+  "vehicleType": "car",
+  "fuelType": "electric",
+  "fuelConsumption": 20.7,
+  "tractionBatteryCapacity": 79
+}

--- a/OS2GPSConnector/VehicleModel/examples/example.jsonld
+++ b/OS2GPSConnector/VehicleModel/examples/example.jsonld
@@ -1,0 +1,16 @@
+{
+  "id": "urn:ngsi-ld:VehicleModel:vehiclemodel:buzz",
+  "type": "VehicleModel",
+  "name": "VW-Buzz",
+  "brandName": "Volkswagen",
+  "modelName": "ID. Buzz",
+  "manufacturerName": "Volkswagen",
+  "vehicleType": "car",
+  "fuelType": "electric",
+  "fuelConsumption": 20.7,
+  "tractionBatteryCapacity": 79,
+  "@context": [
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+    "https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld"
+  ]
+}

--- a/OS2GPSConnector/VehicleModel/schema.json
+++ b/OS2GPSConnector/VehicleModel/schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schemaVersion": "0.0.1",
+  "modelTags": "",
+  "$id": "https://smart-data-models.github.io/dataModel.Transportation/VehicleModel/schema.json",
+  "title": " - Vehicle / Vehicle Model",
+  "description": "This entity models a particular vehicle model, including all properties which are common to multiple vehicle instances belonging to such model.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
+    },
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons"
+    },
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/PhysicalObject-Commons"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "VehicleModel"
+          ],
+          "description": "Property. NGSI Entity type. It has to be VehicleModel"
+        },
+        "vehicleType": {
+          "type": "string",
+          "description": "Property. Type of vehicle from the point of view of its structural characteristics. This is different than the vehicle category . Model:'https://schema.org/Text'. Enum:'agriculturalVehicle, anyVehicle, articulatedVehicle, bicycle, binTrolley, bus, car, caravan, carOrLightVehicle, carWithCaravan, carWithTrailer, cleaningTrolley, constructionOrMaintenanceVehicle, fourWheelDrive, highSidedVehicle, lorry, minibus, moped, motorcycle, motorcycleWithSideCar, motorscooter, sweepingMachine, tanker, threeWheeledVehicle, trailer, tram, twoWheeledVehicle, trolley, van, vehicleWithoutCatalyticConverter, vehicleWithCaravan, vehicleWithTrailer, withEvenNumberedRegistrationPlates, withOddNumberedRegistrationPlates, other'. The following values defined by _VehicleTypeEnum_ and _VehicleTypeEnum2_, [DATEX 2 version 2.3](http://d2docs.ndwcloud.nu/_static/umlmodel/v2.3/index.htm)",
+          "enum": [
+            "agriculturalVehicle",
+            "bicycle",
+            "binTrolley",
+            "bus",
+            "car",
+            "caravan",
+            "carWithCaravan",
+            "carWithTrailer",
+            "cleaningTrolley",
+            "constructionOrMaintenanceVehicle",
+            "lorry",
+            "minibus",
+            "moped",
+            "motorcycle",
+            "motorcycleWithSideCar",
+            "motorscooter",
+            "sweepingMachine",
+            "tanker",
+            "trailer",
+            "tram",
+            "van",
+            "trolley"
+          ]
+        },
+        "brandName": {
+          "type": "string",
+          "description": "Property. Vehicle's brand name. Model:'https://schema.org/brand'"
+        },
+        "modelName": {
+          "type": "string",
+          "description": "Property. Vehicle's model name. Model:'https://schema.org/model'"
+        },
+        "manufacturerName": {
+          "type": "string",
+          "description": "Property. Vehicle's manufacturer name. Model:'https://schema.org/Text'"
+        },
+        "vehicleModelDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Property. The release date of a vehicle model (often used to differentiate versions of the same make and model). Model:'https://schema.org/vehicleModelDate'"
+        },
+        "cargoVolume": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. The available volume for cargo or luggage. For automobiles, this is usually the trunk volume. Model:'https://schema.org/cargoVolume'. Units:'Liters'. If only a single value is provided (type Number) it will refer to the maximum volume"
+        },
+        "fuelType": {
+          "type": "string",
+          "description": "Property. The type of fuel suitable for the engine or engines of the vehicle. Model:'https://schema.org/DateTime'. Enum:'autogas, biodiesel, ethanol, cng, diesel, electric, gasoline, hybrid electric/diesel, hybrid electric/petrol, hydrogen, lpg, petrol, petrol(unleaded), petrol(leaded), other'",
+          "enum": [
+            "autogas",
+            "biodiesel",
+            "cng",
+            "diesel",
+            "electric",
+            "ethanol",
+            "gasoline",
+            "hybrid_electric_diesel",
+            "hybrid_electric_petrol",
+            "hydrogen",
+            "lpg",
+            "petrol",
+            "petrol(unleaded)",
+            "petrol(leaded)",
+            "other"
+          ]
+        },
+        "fuelConsumption": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. The amount of fuel consumed for traveling a particular distance or temporal duration with the given vehicle (e.g. liters per 100 km). Model:'https://schema.org/fuelConsumption'. Units:'liters per 100 kilometer'"
+        },
+        "height": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. Vehicle's height. Model:'https://schema.org/height'"
+        },
+        "tractionBatteryCapacity": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. Vehicle's traction battery capacity. Applies to electrically powered vehicles (e.g. 52 kWh)"
+        },
+        "width": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. Vehicle's width. Model:'https://schema.org/width'"
+        },
+        "depth": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. Vehicle's depth. Model:'https://schema.org/depth'"
+        },
+        "weight": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. Vehicle's weigth. Model:'https://schema.org/weigth'"
+        },
+        "vehicleEngine": {
+          "type": "string",
+          "description": "Property. Information about the engine or engines of the vehicle. Model:'https://schema.org/vehicleEngine'"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Property. URL which provides a description of this vehicle model. Model:'https://schema.org/URL'"
+        }
+      }
+    }
+  ],
+  "required": [
+    "id",
+    "name",
+    "type",
+    "vehicleType",
+    "brandName",
+    "modelName",
+    "manufacturerName"
+  ]
+}


### PR DESCRIPTION
PR to accept a `tractionBatteryCapacity` value in the VehicleModel. 

Adopters will be a project funded by OS2.eu, an open source community for danish municipalities. The project aims to allow municipalities to collect GPS data from their fleet. 
Specifically applicable for enabling further analaysis and optimisation on the fleet by calculating range from battery capacity of BEV. 

As of now, there are no immediate value that is suitable for containing this information.
We suggest a new property that will be dedicated to store the capacity of the battery for vehicles that are fully or partly powered by a traction battery. 

Example files are left out of this commit as `tractionBatteryCapacity` is not applicable on the included example. Let me know if you want the example files to include the new property.
```
  "fuelType": "diesel"
```

Contribution agreement has been signed with my user @andreasDroid

We wish to appear in the `CONTRIBUTORS.yaml` as organisation and not as a specific individual. 