### PR TITLE
add "leasingInfo" property (Vehicle)

### DIFF
--- a/OS2GPSConnector/CONTRIBUTORS.yaml
+++ b/OS2GPSConnector/CONTRIBUTORS.yaml
@@ -1,0 +1,9 @@
+description: This is a compilation list of all CONTRIBUTORS across different objects (data models) alphabetically ordered. All fields are non mandatory
+contributors:
+  - name:
+    surname:
+    mail: os2fleetoptimiser@os2.eu
+    organization: OS2.eu
+    project: OS2 GPS-Connector
+    comments: Project funded by OS2 for danish municipalities.
+    year: 2025

--- a/OS2GPSConnector/Vehicle/ADOPTERS.yaml
+++ b/OS2GPSConnector/Vehicle/ADOPTERS.yaml
@@ -1,0 +1,10 @@
+description: This is a compilation list of the current adopters of the data model Vehicle of the Subject dataModel.Transportation.  All fields are non mandatory. More info at https://smart-data-models.github.io/data-models/templates/dataModel/CURRENT_ADOPTERS.yaml
+currentAdopters:
+-
+ adopter: OS2 GPS-Connector
+ description: Open source project for danish municipalities to collect GPS data for analysis and optimisation
+ mail: os2fleetoptimiser@os2.eu
+ organization: https://www.os2.eu/
+ project: https://github.com/OS2sandbox/gps-connector
+ comments: Storing additional meta-data for vehicle, such as 'leasingInfo', is useful for the municipalities when managing their leased vehicles. Further, it is crucial for analysis and optimisation to bring in values such as 'monthlyLeaseCost' and 'allowedAnnualDistance' to account for the TCO of a vehicle.
+ startDate:

--- a/OS2GPSConnector/Vehicle/examples/example-normalized.json
+++ b/OS2GPSConnector/Vehicle/examples/example-normalized.json
@@ -1,0 +1,183 @@
+{
+  "id": "vehicle:WasteManagement:1",
+  "type": "Vehicle",
+  "category": {
+    "type": "StructuredValue",
+    "value": [
+      "municipalServices"
+    ]
+  },
+  "vehicleType": {
+    "type": "Text",
+    "value": "lorry"
+  },
+  "battery": {
+    "type": "Number",
+    "value": 0.81
+  },
+  "name": {
+    "type": "Text",
+    "value": "C Recogida 1"
+  },
+  "vehiclePlateIdentifier": {
+    "type": "Text",
+    "value": "3456ABC"
+  },
+  "refVehicleModel": {
+    "type": "Text",
+    "value": "vehiclemodel:econic"
+  },
+  "location": {
+    "type": "geo:json",
+    "value": {
+      "type": "Point",
+      "coordinates": [
+        -3.164485591715449,
+        40.62785133667262
+      ]
+    },
+    "metadata": {
+      "timestamp": {
+        "type": "DateTime",
+        "value": "2018-09-27T12:00:00"
+      }
+    }
+  },
+  "areaServed": {
+    "type": "Text",
+    "value": "Centro"
+  },
+  "serviceStatus": {
+    "type": "Text",
+    "value": "onRoute"
+  },
+  "cargoWeight": {
+    "type": "Number",
+    "value": 314
+  },
+  "speed": {
+    "type": "Number",
+    "value": 50,
+    "metadata": {
+      "timestamp": {
+        "type": "DateTime",
+        "value": "2018-09-27T12:00:00"
+      }
+    }
+  },
+  "serviceProvided": {
+    "type": "StructuredValue",
+    "value": [
+      "garbageCollection",
+      "wasteContainerCleaning"
+    ]
+  },
+  "bearing": {
+    "type": "Number",
+    "value": 43
+  },
+  "fuelEfficiency": {
+    "type": "Number",
+    "value": 13
+  },
+  "fuelType": {
+    "type": "Text",
+    "value": "Petrol"
+  },
+  "fuelFilled": {
+    "type": "Number",
+    "value": 6
+  },
+  "tripNetWeightCollected": {
+    "type": "Number",
+    "value": 12
+  },
+  "vehicleTrackerDevice": {
+    "type": "Text",
+    "value": "Installed"
+  },
+  "wardId": {
+    "type": "Text",
+    "value": "4"
+  },
+  "license_plate": {
+    "type": "Text",
+    "value": "KA052134"
+  },
+  "currentTripCount": {
+    "type": "Boolean",
+    "value": true
+  },
+  "reportId": {
+    "type": "Text",
+    "value": "21645"
+  },
+  "zoneName": {
+    "type": "Text",
+    "value": "South Zone"
+  },
+  "vehicleAltitude": {
+    "type": "Text",
+    "value": "600"
+  },
+  "deviceSimNumber": {
+    "type": "Text",
+    "value": "9942142573"
+  },
+  "wardName": {
+    "type": "Text",
+    "value": "Kempegowda Ward"
+  },
+  "deviceBatteryStatus": {
+    "type": "Text",
+    "value": "connected"
+  },
+  "ignitionStatus": {
+    "type": "Boolean",
+    "value": true
+  },
+  "vehicleRunningStatus": {
+    "type": "Text",
+    "value": "running"
+  },
+  "observationDateTime": {
+    "type": "DateTime",
+    "value": "2021-03-11T15:51:02+05:30"
+  },
+  "serviceOnDuty": {
+    "type": "Boolean",
+    "value": false
+  },
+  "emergencyVehicleType": {
+    "type": "Text",
+    "value": "ambulance"
+  },
+  "municipalityInfo": {
+    "type": "StructuredValue",
+    "value": {
+      "district": "Bangalore Urban",
+      "ulbName": "BMC",
+      "cityId": "23",
+      "wardId": "23",
+      "stateName": "Karnataka",
+      "cityName": "Bangalore",
+      "zoneName": "South",
+      "wardName": "Bangalore Urban",
+      "zoneId": "2",
+      "wardNum": 4
+    }
+  },
+  "leasingInfo": {
+    "type": "StructuredValue",
+    "value": {
+      "leasingType": "Operating Lease",
+      "leasingStartDate": "2025-06-01T00:00:00.000Z",
+      "leasingEndDate": "2029-06-01T00:00:00.000Z",
+      "monthlyLeaseCost": 525,
+      "allowedAnnualDistance": 20000,
+      "allowedDistanceUnit": "kilometer",
+      "excessDistanceCost": 1,
+      "leasingProvider": "Municipality Leasing A/S"
+    }
+  }
+}

--- a/OS2GPSConnector/Vehicle/examples/example-normalized.jsonld
+++ b/OS2GPSConnector/Vehicle/examples/example-normalized.jsonld
@@ -1,0 +1,180 @@
+{
+  "id": "urn:ngsi-ld:Vehicle:vehicle:WasteManagement:1",
+  "type": "Vehicle",
+  "areaServed": {
+    "type": "Property",
+    "value": "Centro"
+  },
+  "battery": {
+    "type": "Property",
+    "value": 0.81,
+    "observedAt": "2021-03-11T15:51:02+05:30"
+  },
+  "bearing": {
+    "type": "Property",
+    "value": 43
+  },
+  "cargoWeight": {
+    "type": "Property",
+    "value": 314
+  },
+  "category": {
+    "type": "Property",
+    "value": [
+      "municipalServices"
+    ]
+  },
+  "currentTripCount": {
+    "type": "Property",
+    "value": 1
+  },
+  "deviceBatteryStatus": {
+    "type": "Property",
+    "value": "Connected"
+  },
+  "deviceSimNumber": {
+    "type": "Property",
+    "value": "9942142573"
+  },
+  "emergencyVehicleType": {
+    "type": "Property",
+    "value": "ambulance"
+  },
+  "fuelEfficiency": {
+    "type": "Property",
+    "value": 13
+  },
+  "fuelFilled": {
+    "type": "Property",
+    "value": 6
+  },
+  "fuelType": {
+    "type": "Property",
+    "value": "Petrol"
+  },
+  "ignitionStatus": {
+    "type": "Property",
+    "value": true
+  },
+  "license_plate": {
+    "type": "Property",
+    "value": "KA052134"
+  },
+  "location": {
+    "type": "GeoProperty",
+    "value": {
+      "type": "Point",
+      "coordinates": [
+        -3.164485591715449,
+        40.62785133667262
+      ]
+    },
+    "observedAt": "2018-09-27T12:00:00Z"
+  },
+  "municipalityInfo": {
+    "type": "Property",
+    "value": {
+      "district": "Bangalore Urban",
+      "ulbName": "BMC",
+      "cityId": "23",
+      "wardId": "23",
+      "stateName": "Karnataka",
+      "cityName": "Bangalore",
+      "zoneName": "South",
+      "wardName": "Bangalore Urban",
+      "zoneId": "2",
+      "wardNum": 4
+    }
+  },
+  "leasingInfo": {
+    "type": "Property",
+    "value": {
+      "leasingType": "Operating Lease",
+      "leasingStartDate": "2025-06-01T00:00:00.000Z",
+      "leasingEndDate": "2029-06-01T00:00:00.000Z",
+      "monthlyLeaseCost": 525,
+      "allowedAnnualDistance": 20000,
+      "allowedDistanceUnit": "kilometer",
+      "excessDistanceCost": 1,
+      "leasingProvider": "Municipality Leasing A/S"
+    }
+  },
+  "name": {
+    "type": "Property",
+    "value": "C Recogida 1"
+  },
+  "observationDateTime": {
+    "type": "Property",
+    "value": {
+      "@type": "DateTime",
+      "@value": "2021-03-11T15:51:02+05:30"
+    }
+  },
+  "refVehicleModel": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:VehicleModel:vehiclemodel:econic"
+  },
+  "reportId": {
+    "type": "Property",
+    "value": "21645"
+  },
+  "serviceOnDuty": {
+    "type": "Property",
+    "value": false
+  },
+  "serviceProvided": {
+    "type": "Property",
+    "value": [
+      "garbageCollection",
+      "wasteContainerCleaning"
+    ]
+  },
+  "serviceStatus": {
+    "type": "Property",
+    "value": "onRoute"
+  },
+  "speed": {
+    "type": "Property",
+    "value": 50,
+    "observedAt": "2018-09-27T12:00:00Z"
+  },
+  "tripNetWeightCollected": {
+    "type": "Property",
+    "value": 12
+  },
+  "vehicleAltitude": {
+    "type": "Property",
+    "value": 600
+  },
+  "vehiclePlateIdentifier": {
+    "type": "Property",
+    "value": "3456ABC"
+  },
+  "vehicleRunningStatus": {
+    "type": "Property",
+    "value": "running"
+  },
+  "vehicleTrackerDevice": {
+    "type": "Property",
+    "value": "Installed"
+  },
+  "vehicleType": {
+    "type": "Property",
+    "value": "lorry"
+  },
+  "wardId": {
+    "type": "Property",
+    "value": "4"
+  },
+  "wardName": {
+    "type": "Property",
+    "value": "Kempegowda Ward"
+  },
+  "zoneName": {
+    "type": "Property",
+    "value": "South Zone"
+  },
+  "@context": [
+    "https://smart-data-models.github.io/dataModel.Transportation/context.jsonld"
+  ]
+}

--- a/OS2GPSConnector/Vehicle/examples/example.json
+++ b/OS2GPSConnector/Vehicle/examples/example.json
@@ -1,0 +1,69 @@
+{
+  "id": "vehicle:WasteManagement:1",
+  "type": "Vehicle",
+  "vehicleType": "lorry",
+  "battery": 0.81,
+  "category": [
+    "municipalServices"
+  ],
+  "location": {
+    "type": "Point",
+    "coordinates": [
+      -3.164485591715449,
+      40.62785133667262
+    ]
+  },
+  "name": "C Recogida 1",
+  "speed": 50,
+  "cargoWeight": 314,
+  "serviceStatus": "onRoute",
+  "serviceProvided": [
+    "garbageCollection",
+    "wasteContainerCleaning"
+  ],
+  "areaServed": "Centro",
+  "refVehicleModel": "vehiclemodel:econic",
+  "vehiclePlateIdentifier": "3456ABC",
+  "bearing": 43,
+  "fuelEfficiency": 13,
+  "fuelType": "Petrol",
+  "fuelFilled": 6,
+  "tripNetWeightCollected": 12,
+  "vehicleTrackerDevice": "Installed",
+  "wardId": "4",
+  "license_plate": "KA052134",
+  "currentTripCount": 1,
+  "reportId": "21645",
+  "zoneName": "South Zone",
+  "vehicleAltitude": "600",
+  "deviceSimNumber": "9942142573",
+  "wardName": "Kempegowda Ward",
+  "deviceBatteryStatus": "connected",
+  "ignitionStatus": true,
+  "vehicleRunningStatus": "running",
+  "observationDateTime": "2021-03-11T15:51:02+05:30",
+  "serviceOnDuty": false,
+  "emergencyVehicleType": "ambulance",
+  "municipalityInfo": {
+    "district": "Bangalore Urban",
+    "ulbName": "BMC",
+    "cityId": "23",
+    "wardId": "23",
+    "stateName": "Karnataka",
+    "cityName": "Bangalore",
+    "zoneName": "South",
+    "wardName": "Bangalore Urban",
+    "zoneId": "2",
+    "wardNum": 4
+  },
+  "leasingInfo": {
+    "leasingType": "Operating Lease",
+    "leasingStartDate": "2025-06-01T00:00:00.000Z",
+    "leasingEndDate": "2029-06-01T00:00:00.000Z",
+    "monthlyLeaseCost": 525,
+    "allowedAnnualDistance": 20000,
+    "allowedDistanceUnit": "kilometer",
+    "excessDistanceCost": 1,
+    "leasingProvider": "Municipality Leasing A/S"
+  }
+}

--- a/OS2GPSConnector/Vehicle/examples/example.jsonld
+++ b/OS2GPSConnector/Vehicle/examples/example.jsonld
@@ -1,0 +1,72 @@
+{
+  "id": "urn:ngsi-ld:Vehicle:vehicle:WasteManagement:1",
+  "type": "Vehicle",
+  "areaServed": "Centro",
+  "battery": 0.81,
+  "bearing": 43,
+  "cargoWeight": 314,
+  "category": [
+    "municipalServices"
+  ],
+  "currentTripCount": 1,
+  "deviceBatteryStatus": "connected",
+  "deviceSimNumber": "9942142573",
+  "emergencyVehicleType": "ambulance",
+  "fuelEfficiency": 13,
+  "fuelFilled": 6,
+  "fuelType": "Petrol",
+  "ignitionStatus": true,
+  "license_plate": "KA052134",
+  "location": {
+    "coordinates": [
+      -3.164485591715449,
+      40.62785133667262
+    ],
+    "type": "Point"
+  },
+  "municipalityInfo": {
+    "district": "Bangalore Urban",
+    "ulbName": "BMC",
+    "cityId": "23",
+    "wardId": "23",
+    "stateName": "Karnataka",
+    "cityName": "Bangalore",
+    "zoneName": "South",
+    "wardName": "Bangalore Urban",
+    "zoneId": "2",
+    "wardNum": 4
+  },
+  "leasingInfo": {
+    "leasingType": "Operating Lease",
+    "leasingStartDate": "2025-06-01T00:00:00.000Z",
+    "leasingEndDate": "2029-06-01T00:00:00.000Z",
+    "monthlyLeaseCost": 525,
+    "allowedAnnualDistance": 20000,
+    "allowedDistanceUnit": "kilometer",
+    "excessDistanceCost": 1,
+    "leasingProvider": "Municipality Leasing A/S"
+  },
+  "name": "C Recogida 1",
+  "observationDateTime": "2021-03-11T15:51:02+05:30",
+  "refVehicleModel": "urn:ngsi-ld:VehicleModel:vehiclemodel:econic",
+  "reportId": "21645",
+  "serviceOnDuty": false,
+  "serviceProvided": [
+    "garbageCollection",
+    "wasteContainerCleaning"
+  ],
+  "serviceStatus": "onRoute",
+  "speed": 50,
+  "tripNetWeightCollected": 12,
+  "vehicleAltitude": "600",
+  "vehiclePlateIdentifier": "3456ABC",
+  "vehicleRunningStatus": "running",
+  "vehicleTrackerDevice": "Installed",
+  "vehicleType": "lorry",
+  "wardId": "4",
+  "wardName": "Kempegowda Ward",
+  "zoneName": "South Zone",
+  "@context": [
+    "https://smart-data-models.github.io/dataModel.Transportation/context.jsonld"
+  ]
+}

--- a/OS2GPSConnector/Vehicle/schema.json
+++ b/OS2GPSConnector/Vehicle/schema.json
@@ -1,0 +1,477 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schemaVersion": "0.2.2",
+  "modelTags": "IUDX, SEDIMARK",
+  "$id": "https://smart-data-models.github.io/dataModel.Transportation/Vehicle/schema.json",
+  "title": "Smart Data Models - Vehicle",
+  "description": "This entity models a particular vehicle model, including all properties which are common to multiple vehicle instances belonging to such model.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
+    },
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons"
+    },
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/PhysicalObject-Commons"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Vehicle"
+          ],
+          "description": "Property. NGSI Entity type. It has to be Vehicle"
+        },
+        "vehicleType": {
+          "type": "string",
+          "description": "Property. Type of vehicle from the point of view of its structural characteristics. This is different than the vehicle category . Model:'https://schema.org/Text'. Enum:'agriculturalVehicle, anyVehicle, articulatedVehicle, bicycle, binTrolley, bus, car, caravan, carOrLightVehicle, carWithCaravan, carWithTrailer, cleaningTrolley, constructionOrMaintenanceVehicle, fourWheelDrive, highSidedVehicle, lorry, minibus, moped, motorcycle, motorcycleWithSideCar, motorscooter, sweepingMachine, tanker, threeWheeledVehicle, trailer, tram, twoWheeledVehicle, trolley, van, vehicleWithoutCatalyticConverter, vehicleWithCaravan, vehicleWithTrailer, withEvenNumberedRegistrationPlates, withOddNumberedRegistrationPlates, other'. The following values defined by _VehicleTypeEnum_ and _VehicleTypeEnum2_, [DATEX 2 version 2.3](http://d2docs.ndwcloud.nu/_static/umlmodel/v2.3/index.htm) and extended for other uses",
+          "enum": [
+            "agriculturalVehicle",
+            "ambulance",
+            "anyVehicle",
+            "articulatedVehicle",
+            "autorickshaw",
+            "bicycle",
+            "binTrolley",
+            "BRT mini bus\u00b7",
+            "BRT bus",
+            "bus",
+            "car",
+            "caravan",
+            "carOrLightVehicle",
+            "carWithCaravan",
+            "carWithTrailer",
+            "cleaningTrolley",
+            "compactor",
+            "constructionOrMaintenanceVehicle",
+            "dumper",
+            "e-bike",
+            "e-moped",
+            "e-scooter",
+            "e-motorcycle",
+            "fireTender",
+            "fourWheelDrive",
+            "highSidedVehicle",
+            "hopper",
+            "lorry",
+            "minibus",
+            "moped",
+            "motorcycle",
+            "motorcycleWithSideCar",
+            "motorscooter",
+            "policeVan",
+            "publicMotor",
+            "sweepingMachine",
+            "tanker",
+            "tempo",
+            "threeWheeledVehicle",
+            "tipper",
+            "trailer",
+            "tram",
+            "trolley",
+            "twoWheeledVehicle",
+            "van",
+            "vehicleWithoutCatalyticConverter",
+            "vehicleWithCaravan",
+            "vehicleWithTrailer",
+            "withEvenNumberedRegistrationPlates",
+            "withOddNumberedRegistrationPlates",
+            "pilotVessel",
+            "passengerVessel",
+            "cargoVessel",
+            "tug",
+            "militaryVessel",
+            "sailingVessel",
+            "vessel",
+            "other"
+          ]
+        },
+        "battery": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Property. The current percentage of battery left in case of an electric vehicle, or a device connected to the vehicle"
+        },
+        "category": {
+          "type": "array",
+          "description": "Property. Vehicle category(ies) from an external point of view. This is different than the vehicle type (car, lorry, etc.) represented by the `vehicleType` property. Model:'https://schema.org/Text'. Enum:'municipalServices, nonTracked, private, public, specialUsage, tracked'. Tracked vehicles are those vehicles which position is permanently tracked by a remote system. Or any other needed by an application They incorporate a GPS receiver together with a network connection to periodically update a reported position (location, speed, heading ...)",
+          "items": {
+            "type": "string",
+            "enum": [
+              "municipalServices",
+              "nonTracked",
+              "private",
+              "public",
+              "specialUsage",
+              "tracked"
+            ]
+          }
+        },
+        "previousLocation": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons/properties/location"
+        },
+        "speed": {
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "number",
+              "minimum": -1,
+              "maximum": -1
+            }
+          ],
+          "description": "Property. Denotes the magnitude of the horizontal component of the vehicle's current velocity and is specified in Kilometers per Hour. If provided, the value of the speed attribute must be a non-negative real number. `-1` MAY be used if speed is transiently unknown for some reason. Model:'https://schema.org/Number'. Units:'Km/h'"
+        },
+        "heading": {
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 360,
+              "exclusiveMaximum": 360
+            },
+            {
+              "type": "number",
+              "enum": [
+                -1
+              ]
+            }
+          ],
+          "description": "Property. Denotes the direction of travel of the vehicle and is specified in decimal degrees, where 0 <= `heading` < 360, counting clockwise relative to the true north. If the vehicle is stationary (i.e. the value of the `speed` attribute is `0`), then the value of the heading attribute must be equal to `-1`. Model:'https://schema.org/Number'. Units:'Degree'"
+        },
+        "cargoWeight": {
+          "type": "number",
+          "description": "Property. Current weight of the vehicle's cargo. Model:'https://schema.org/Number'. Units:'Kilograms'",
+          "minimum": 0,
+          "exclusiveMinimum": 0
+        },
+        "vehicleIdentificationNumber": {
+          "type": "string",
+          "description": "Property. The Vehicle Identification Number (VIN) is a unique serial number used by the automotive industry to identify individual motor vehicles. Model:'https://schema.org/vehicleIdentificationNumber'"
+        },
+        "vehiclePlateIdentifier": {
+          "type": "string",
+          "description": "Property.  An identifier or code displayed on a vehicle registration plate attached to the vehicle used for official identification purposes. The registration identifier is numeric or alphanumeric and is unique within the issuing authority's region. Model:'https://schema.org/Text'. Normative References: DATEXII `vehicleRegistrationPlateIdentifier`"
+        },
+        "fleetVehicleId": {
+          "type": "string",
+          "description": "Property. The identifier of the vehicle in the context of the fleet of vehicles to which it belongs. Model:'https://schema.org/Text'"
+        },
+        "dateVehicleFirstRegistered": {
+          "type": "string",
+          "format": "date",
+          "description": "Property. The date of the first registration of the vehicle with the respective public authorities. Model:'https://schema.org/dateVehicleFirstRegistered'"
+        },
+        "dateFirstUsed": {
+          "type": "string",
+          "format": "date",
+          "description": "Property. Timestamp which denotes when the vehicle was first used. Model:'https://schema.org/DateTime'"
+        },
+        "purchaseDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Property. The date the item e.g. vehicle was purchased by the current owner. Model:'https://schema.org/purchaseDate'"
+        },
+        "mileageFromOdometer": {
+          "type": "number",
+          "description": "Property. The total distance travelled by the particular vehicle since its initial production, as read from its odometer. Model:'https://schema.org/mileageFromOdometer'"
+        },
+        "vehicleConfiguration": {
+          "type": "string",
+          "description": "Property. A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'. Model:'https://schema.org/vehicleConfiguration'"
+        },
+        "feature": {
+          "type": "array",
+          "description": "Property. Feature(s) incorporated by the vehicle. Model:'https://schema.org/Text'. Enum:' abs, airbag, alarm, backCamera, disabledRamp, gps, internetConnection, overspeed, proximitySensor, wifi'. Or any other needed by the application. In order to represent multiple instances of a feature it can be used the following syntax: `<feature>,<occurences>`. For example, a car with 4 airbags will be represented by `airbag,4`",
+          "items": {
+            "type": "string",
+            "enum": [
+              "abs",
+              "airbag",
+              "alarm",
+              "backCamera",
+              "disabledRamp",
+              "gps",
+              "internetConnection",
+              "overspeed",
+              "proximitySensor",
+              "wifi"
+            ]
+          }
+        },
+        "serviceProvided": {
+          "type": "array",
+          "description": "Property. Service(s) the vehicle is capable of providing or it is assigned to. Model:'https://schema.org/Text'. Enum:'auxiliaryServices, cargoTransport, construction, fairground, garbageCollection, goodsSelling, maintenance, parksAndGardens, roadSignalling, specialTransport, streetCleaning, streetLighting, urbanTransit, wasteContainerCleaning'. Or any other value needed by an specific application",
+          "items": {
+            "type": "string",
+            "enum": [
+              "auxiliaryServices",
+              "cargoTransport",
+              "construction",
+              "fairground",
+              "garbageCollection",
+              "goodsSelling",
+              "maintenance",
+              "parksAndGardens",
+              "roadSignalling",
+              "specialTransport",
+              "streetCleaning",
+              "streetLighting",
+              "urbanTransit",
+              "wasteContainerCleaning"
+            ]
+          }
+        },
+        "vehicleSpecialUsage": {
+          "type": "string",
+          "description": "Property. Indicates whether the vehicle is been used for special purposes, like commercial rental, driving school, or as a taxi. The legislation in many countries requires this information to be revealed when offering a car for sale. Model:'https://schema.org/vehicleSpecialUsage'. Enum:'ambulance, fireBrigade, military, police, schoolTransportation, taxi, trashManagement'",
+          "enum": [
+            "ambulance",
+            "fireBrigade",
+            "military",
+            "police",
+            "schoolTransportation",
+            "taxi",
+            "trashManagement"
+          ]
+        },
+        "refVehicleModel": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+              "description": "Property. Identifier format of any NGSI entity"
+            },
+            {
+              "type": "string",
+              "format": "uri",
+              "description": "Property. Identifier format of any NGSI entity"
+            }
+          ],
+          "description": "Relationship. Model:'https://schema.org/URL'. Reference to a VehicleModel"
+        },
+        "serviceStatus": {
+          "type": "string",
+          "description": "Property. Vehicle status (from the point of view of the service provided, so it could not apply to private vehicles). Model:'https://schema.org/DateTime'. `parked` : Vehicle is parked and not providing any service at the moment. `onRoute` : Vehicle is performing a mission. A comma-separated modifier(s) can be added to indicate what mission is currently delivering the vehicle. For instance `onRoute,garbageCollection` can be used to denote that the vehicle is on route and in a garbage collection mission. 'broken' : Vehicle is suffering a temporary breakdown. `outOfService` : Vehicle is on the road but not performing any mission, probably going to its parking area. Enum:'broken, onRoute, outOfService, parked'",
+          "enum": [
+            "broken",
+            "onRoute",
+            "outOfService",
+            "parked"
+          ]
+        },
+        "bearing": {
+          "type": "number",
+          "description": "Property. Model:'https://schema.org/Number'. Gives the vehicle GPS angle measured in a clockwise direction from the True North. SameAs 'bearing' field from GTFS Realtime message-Position(https://developers.google.com/transit/gtfs-realtime/reference#message-position)"
+        },
+        "wardId": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. Ward ID of the entity corresponding to this observation"
+        },
+        "tripNetWeightCollected": {
+          "type": "number",
+          "description": "Property. Model:'https://schema.org/Number'. The net weight collected by the vehicle corresponding to this observation at the end of the trip"
+        },
+        "license_plate": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. Gives the License Plate number of the vehicle. SameAs: license_plate field from GTFS Realtime message-VehicleDescriptor (https://developers.google.com/transit/gtfs-realtime/reference#message-vehicledescriptor)'"
+        },
+        "deviceBatteryStatus": {
+          "type": "string",
+          "enum": [
+            "connected",
+            "disconnected"
+          ],
+          "description": "Property. Model:'https://schema.org/Text'. Gives the Battery charging status of the reporting device. Enum:'connected, disconnected'"
+        },
+        "ignitionStatus": {
+          "type": "boolean",
+          "description": "Property. Model:'https://schema.org/Boolean'. Gives the ignition status of the vehicle. True means ignited"
+        },
+        "vehicleRunningStatus": {
+          "type": "string",
+          "enum": [
+            "running",
+            "stopped",
+            "waiting"
+          ],
+          "description": "Property. Model:'https://schema.org/Text'. Gives the Battery charging status of the reporting device. Enum:'running, waiting, stopped'"
+        },
+        "currentTripCount": {
+          "type": "number",
+          "description": "Property. Model:'https://schema.org/Number'. The current count of trips made by the vehicle corresponding to this observation on the given day of operation"
+        },
+        "zoneName": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. Zone name of the entity corresponding to this observation"
+        },
+        "vehicleAltitude": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. Gives the current altitude of the vehicle using GPS"
+        },
+        "observationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Property. Model:'https://schema.org/DateTime'. Last reported time of observation"
+        },
+        "deviceSimNumber": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. Gives the SIM number of the device in the vehicle"
+        },
+        "wardName": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. Ward name of the entity corresponding to this observation"
+        },
+        "reportId": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. Unique Id assigned for the issue or report or feedback or transaction corresponding to this observation"
+        },
+        "vehicleTrackerDevice": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. Installation status of the GPS device or the tracking device fitted to the vehicle corresponding to this observation"
+        },
+        "fuelFilled": {
+          "type": "number",
+          "description": "Property. Model:'https://schema.org/Number'. Amount of fuel filled in liters to the vehicle corresponding to this observation"
+        },
+        "fuelEfficiency": {
+          "type": "number",
+          "description": "Property. Model:'https://schema.org/Number'. The distance traveled per unit of fuel used, commonly in kilometers per liter (km/L)"
+        },
+        "fuelType": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. The type of fuel suitable for the engine or engines of the vehicle corresponding to this observation"
+        },
+        "serviceOnDuty": {
+          "type": "boolean",
+          "description": "Property. Model:'https://schema.org/Boolean'. Nature of service provided by emergency vehicle corresponding to this observation. True indicates the emergency vehicle corresponding to this observation is attending to/ servicing to an emergency call of duty and is False otherwise"
+        },
+        "emergencyVehicleType": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/Text'. Type of emergency vehicle corresponding to this observation. Enum:'policeCar, policeMotorcycle, policeVan, policeSWAT, fireEngine, waterTender, airAmbulance, ambulance, motorcycleAmbulance, rescueVehicle, hazardousMaterialsApparatus, towTruck",
+          "enum": [
+            "policeCar",
+            "policeMotorcycle",
+            "policeVan",
+            "policeSWAT",
+            "fireEngine",
+            "waterTender",
+            "airAmbulance",
+            "ambulance",
+            "motorcycleAmbulance",
+            "rescueVehicle",
+            "hazardousMaterialsApparatus",
+            "towTruck"
+          ]
+        },
+        "municipalityInfo": {
+          "type": "object",
+          "description": "Property. Model:'https://schema.org/Text. Municipality information corresponding to this observation",
+          "properties": {
+            "district": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. District name corresponding to this observation"
+            },
+            "ulbName": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. Name of the Urban Local Body corresponding to this observation"
+            },
+            "cityId": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. City ID corresponding to this observation"
+            },
+            "wardId": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. Ward ID corresponding to this observation"
+            },
+            "stateName": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. Name of the state corresponding to this observation"
+            },
+            "cityName": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. City name corresponding to this observation"
+            },
+            "zoneName": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. Zone name corresponding to this observation"
+            },
+            "zoneId": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. Zone ID corresponding to this observation"
+            },
+            "wardName": {
+              "type": "string",
+              "description": "Property. Model:'https://schema.org/Text'. Ward name corresponding to this observation"
+            },
+            "wardNum": {
+              "type": "number",
+              "description": "Property. Model:'https://schema.org/Number'. Ward number corresponding to this observation"
+            }
+          }
+        },
+        "leasingInfo": {
+          "type": "object",
+          "description": "Property. Leasing contract information for the vehicle.",
+          "properties": {
+            "leasingType": {
+              "type": "string",
+              "description": "Property. Type of leasing contract"
+            },
+            "leasingStartDate": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Property. Model:'https://schema.org/DateTime'. Start date of the leasing contract"
+            },
+            "leasingEndDate": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Property. Model:'https://schema.org/DateTime'. End date of the leasing contract"
+            },
+            "monthlyLeaseCost": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Property. Fixed monthly lease payment amount in the contract currency"
+            },
+            "allowedAnnualDistance": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Property. Maximum allowed annual distance according to lease contract"
+            },
+            "allowedDistanceUnit": {
+              "type": "string",
+              "enum": [
+                "kilometer",
+                "mile"
+              ],
+              "description": "Property. Unit for distance measurements in the lease contract"
+            },
+            "excessDistanceCost": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Property. Cost per unit distance for exceeding the allowed annual distance"
+            },
+            "leasingProvider": {
+              "type": "string",
+              "description": "Property. Name or identifier of the leasing company"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "id",
+    "type",
+    "vehicleType",
+    "category",
+    "location"
+  ]
+}


### PR DESCRIPTION
PR to accept a `leasingInfo` value in the `Vehicle`.

Adopters will be a project funded by OS2.eu, an open source community for danish municipalities. The project aims to allow municipalities to collect GPS data from their fleet.

As of now, there is no obvious place to store information relevant to leasing information. This information is essential for municipalities in order to track their leasing contracts and the service. 

Contribution agreement has been signed with my user @andreasDroid
We wish to appear in the `CONTRIBUTORS.yaml` as organisation and not as a specific individual.