### PR TITLE
Add EnergyCommunity subject with EnergyCommunity and EnergyProsumer data models

### DIFF
--- a/SMARTENERGY/EnergyCommunity/ADOPTERS.yaml
+++ b/SMARTENERGY/EnergyCommunity/ADOPTERS.yaml
@@ -1,0 +1,34 @@
+description: >
+  This is a compilation list of current adopters of the EnergyCommunity
+  subject. All fields are optional.
+
+currentAdopters:
+
+  - adopter: Open Remote
+    description: Adoption of EnergyCommunity and EnergyProsumer data models
+      for energy community management and flexibility orchestration.
+    organization: Open Remote
+    project: RESCHOOL
+    comments: EU project focused on creation and management of energy communities.
+
+  - adopter: Bamboo Energy
+    description: Use of EnergyCommunity and EnergyProsumer data models
+      in distributed energy resource management and optimization solutions.
+    organization: Bamboo Energy
+    project: RESCHOOL
+    comments: EU project focused on creation and management of energy communities.
+
+  - adopter: LocalLife
+    description: Adoption of EnergyCommunity data model to support local
+      energy communities and collective self-consumption.
+    organization: LocalLife
+    project: RESCHOOL
+    comments: EU project focused on creation and management of energy communities.
+    
+  - adopter: COEN
+    description: Use of EnergyCommunity and EnergyProsumer data models
+      in research and pilot projects related to smart grids and community-based
+      energy systems.
+    organization: COEN
+    project: RESCHOOL
+    comments: EU project focused on creation and management of energy communities.

--- a/SMARTENERGY/EnergyCommunity/CONTRIBUTORS.yaml
+++ b/SMARTENERGY/EnergyCommunity/CONTRIBUTORS.yaml
@@ -8,5 +8,5 @@ contributors:
     surname: Jolak
     organization: RISE Research Institutes of Sweden
     project: RESCHOOL EU Project
-    comments: Contributor of EnergyCommunity and EnergyProsumer data models.
+    comments: Contributor of EnergyCommunity Subject as well as EnergyCommunity and EnergyProsumer data models.
     year: 2026

--- a/SMARTENERGY/EnergyCommunity/CONTRIBUTORS.yaml
+++ b/SMARTENERGY/EnergyCommunity/CONTRIBUTORS.yaml
@@ -1,0 +1,12 @@
+description: >
+  This is a compilation list of contributors across data models
+  in the EnergyCommunity subject.
+
+contributors:
+
+  - name: Rodi
+    surname: Jolak
+    organization: RISE Research Institutes of Sweden
+    project: RESCHOOL EU Project
+    comments: Contributor of EnergyCommunity and EnergyProsumer data models.
+    year: 2026

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/context.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/context.jsonld
@@ -1,0 +1,37 @@
+{
+  "@context": [
+    "https://schema.lab.fiware.org/ld/context",
+    "https://smart-data-models.github.io/data-models/context.jsonld",
+    {
+      "EnergyCommunity": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyCommunity",
+
+      "communityType": "https://smart-data-models.github.io/dataModel.EnergyCommunity/communityType",
+      "regulatoryFramework": "https://smart-data-models.github.io/dataModel.EnergyCommunity/regulatoryFramework",
+
+      "hasMember": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/hasMember",
+        "@type": "@id"
+      },
+
+      "aggregates": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/aggregates",
+        "@type": "@id"
+      },
+
+      "aggregatesConsumption": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/aggregatesConsumption",
+        "@type": "@id"
+      },
+
+      "aggregatesProduction": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/aggregatesProduction",
+        "@type": "@id"
+      },
+
+      "usesWeatherForecast": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/usesWeatherForecast",
+        "@type": "@id"
+      }
+    }
+  ]
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/context.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/context.jsonld
@@ -2,11 +2,22 @@
   "@context": [
     "https://schema.lab.fiware.org/ld/context",
     "https://smart-data-models.github.io/data-models/context.jsonld",
-    {
-      "EnergyCommunity": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyCommunity",
 
-      "communityType": "https://smart-data-models.github.io/dataModel.EnergyCommunity/communityType",
-      "regulatoryFramework": "https://smart-data-models.github.io/dataModel.EnergyCommunity/regulatoryFramework",
+    {
+      "@vocab": "https://smart-data-models.github.io/dataModel.EnergyCommunity/",
+
+      "EnergyCommunity": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyCommunity",
+        "@type": "@id"
+      },
+
+      "communityType": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/communityType"
+      },
+
+      "regulatoryFramework": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/regulatoryFramework"
+      },
 
       "hasMember": {
         "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/hasMember",

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/context.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/context.jsonld
@@ -7,8 +7,7 @@
       "@vocab": "https://smart-data-models.github.io/dataModel.EnergyCommunity/",
 
       "EnergyCommunity": {
-        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyCommunity",
-        "@type": "@id"
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyCommunity"
       },
 
       "communityType": {

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example-normalized.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example-normalized.json
@@ -1,0 +1,74 @@
+{
+  "id": "urn:ngsi-ld:EnergyCommunity:community-001",
+  "type": "EnergyCommunity",
+
+  "name": {
+    "type": "Property",
+    "value": "Göteborg Renewable Energy Community"
+  },
+
+  "description": {
+    "type": "Property",
+    "value": "Local energy community enabling shared photovoltaic generation, storage, and collective self-consumption."
+  },
+
+  "location": {
+    "type": "GeoProperty",
+    "value": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [11.960, 57.700],
+          [11.990, 57.700],
+          [11.990, 57.720],
+          [11.960, 57.720],
+          [11.960, 57.700]
+        ]
+      ]
+    }
+  },
+
+  "communityType": {
+    "type": "Property",
+    "value": "RenewableEnergyCommunity"
+  },
+
+  "regulatoryFramework": {
+    "type": "Property",
+    "value": "EU Renewable Energy Directive (RED II)"
+  },
+
+  "hasMember": {
+    "type": "Relationship",
+    "value": [
+      "urn:ngsi-ld:EnergyProsumer:prosumer-001",
+      "urn:ngsi-ld:EnergyProsumer:prosumer-002"
+    ]
+  },
+
+  "aggregates": {
+    "type": "Relationship",
+    "value": [
+      "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
+      "urn:ngsi-ld:Battery:battery-001",
+      "urn:ngsi-ld:SpaceHeater:spaceheater-001",
+      "urn:ngsi-ld:Vehicle:vehicle-001",
+      "urn:ngsi-ld:EVChargingStation:charger-001"
+    ]
+  },
+
+  "aggregatesConsumption": {
+    "type": "Relationship",
+    "value": "urn:ngsi-ld:Consumption:community-consumption-001"
+  },
+
+  "aggregatesProduction": {
+    "type": "Relationship",
+    "value": "urn:ngsi-ld:GreenEnergyMeasurement:community-production-001"
+  },
+
+  "usesWeatherForecast": {
+    "type": "Relationship",
+    "value": "urn:ngsi-ld:Weather:weather-001"
+  }
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example-normalized.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example-normalized.json
@@ -38,37 +38,52 @@
     "value": "EU Renewable Energy Directive (RED II)"
   },
 
-  "hasMember": {
-    "type": "Relationship",
-    "value": [
-      "urn:ngsi-ld:EnergyProsumer:prosumer-001",
-      "urn:ngsi-ld:EnergyProsumer:prosumer-002"
-    ]
-  },
+  "hasMember": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:EnergyProsumer:prosumer-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:EnergyProsumer:prosumer-002"
+    }
+  ],
 
-  "aggregates": {
-    "type": "Relationship",
-    "value": [
-      "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
-      "urn:ngsi-ld:Battery:battery-001",
-      "urn:ngsi-ld:SpaceHeater:spaceheater-001",
-      "urn:ngsi-ld:Vehicle:vehicle-001",
-      "urn:ngsi-ld:EVChargingStation:charger-001"
-    ]
-  },
+  "aggregates": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:PhotovoltaicDevice:pv-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Battery:battery-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:SpaceHeater:spaceheater-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Vehicle:vehicle-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:EVChargingStation:charger-001"
+    }
+  ],
 
   "aggregatesConsumption": {
     "type": "Relationship",
-    "value": "urn:ngsi-ld:Consumption:community-consumption-001"
+    "object": "urn:ngsi-ld:Consumption:community-consumption-001"
   },
 
   "aggregatesProduction": {
     "type": "Relationship",
-    "value": "urn:ngsi-ld:GreenEnergyMeasurement:community-production-001"
+    "object": "urn:ngsi-ld:GreenEnergyMeasurement:community-production-001"
   },
 
   "usesWeatherForecast": {
     "type": "Relationship",
-    "value": "urn:ngsi-ld:Weather:weather-001"
+    "object": "urn:ngsi-ld:Weather:weather-001"
   }
 }

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example-normalized.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example-normalized.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://smart-data-models.github.io/dataModel.EnergyCommunity/context.jsonld",
+    "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyCommunity/context.jsonld",
     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
   ],
   "id": "urn:ngsi-ld:EnergyCommunity:community-001",
@@ -42,24 +42,39 @@
     "value": "EU Renewable Energy Directive (RED II)"
   },
 
-  "hasMember": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:EnergyProsumer:prosumer-001",
-      "urn:ngsi-ld:EnergyProsumer:prosumer-002"
-    ]
-  },
+  "hasMember": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:EnergyProsumer:prosumer-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:EnergyProsumer:prosumer-002"
+    }
+  ],
 
-  "aggregates": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
-      "urn:ngsi-ld:Battery:battery-001",
-      "urn:ngsi-ld:SpaceHeater:spaceheater-001",
-      "urn:ngsi-ld:Vehicle:vehicle-001",
-      "urn:ngsi-ld:EVChargingStation:charger-001"
-    ]
-  },
+  "aggregates": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:PhotovoltaicDevice:pv-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Battery:battery-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:SpaceHeater:spaceheater-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Vehicle:vehicle-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:EVChargingStation:charger-001"
+    }
+  ],
 
   "aggregatesConsumption": {
     "type": "Relationship",

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example-normalized.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example-normalized.jsonld
@@ -1,0 +1,78 @@
+{
+  "@context": [
+    "https://smart-data-models.github.io/dataModel.EnergyCommunity/context.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+  ],
+  "id": "urn:ngsi-ld:EnergyCommunity:community-001",
+  "type": "EnergyCommunity",
+
+  "name": {
+    "type": "Property",
+    "value": "Göteborg Renewable Energy Community"
+  },
+
+  "description": {
+    "type": "Property",
+    "value": "Local energy community enabling shared photovoltaic generation, storage, and collective self-consumption."
+  },
+
+  "location": {
+    "type": "GeoProperty",
+    "value": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [11.960, 57.700],
+          [11.990, 57.700],
+          [11.990, 57.720],
+          [11.960, 57.720],
+          [11.960, 57.700]
+        ]
+      ]
+    }
+  },
+
+  "communityType": {
+    "type": "Property",
+    "value": "RenewableEnergyCommunity"
+  },
+
+  "regulatoryFramework": {
+    "type": "Property",
+    "value": "EU Renewable Energy Directive (RED II)"
+  },
+
+  "hasMember": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:EnergyProsumer:prosumer-001",
+      "urn:ngsi-ld:EnergyProsumer:prosumer-002"
+    ]
+  },
+
+  "aggregates": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
+      "urn:ngsi-ld:Battery:battery-001",
+      "urn:ngsi-ld:SpaceHeater:spaceheater-001",
+      "urn:ngsi-ld:Vehicle:vehicle-001",
+      "urn:ngsi-ld:EVChargingStation:charger-001"
+    ]
+  },
+
+  "aggregatesConsumption": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Consumption:community-consumption-001"
+  },
+
+  "aggregatesProduction": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:GreenEnergyMeasurement:community-production-001"
+  },
+
+  "usesWeatherForecast": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Weather:weather-001"
+  }
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example.json
@@ -1,0 +1,40 @@
+{
+  "id": "urn:ngsi-ld:EnergyCommunity:community-001",
+  "type": "EnergyCommunity",
+
+  "name": "Göteborg Renewable Energy Community",
+  "description": "Local energy community enabling shared photovoltaic generation, storage, and collective self-consumption.",
+
+  "location": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [11.960, 57.700],
+        [11.990, 57.700],
+        [11.990, 57.720],
+        [11.960, 57.720],
+        [11.960, 57.700]
+      ]
+    ]
+  },
+
+  "communityType": "RenewableEnergyCommunity",
+  "regulatoryFramework": "EU Renewable Energy Directive (RED II)",
+
+  "hasMember": [
+    "urn:ngsi-ld:EnergyProsumer:prosumer-001",
+    "urn:ngsi-ld:EnergyProsumer:prosumer-002"
+  ],
+
+  "aggregates": [
+    "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
+    "urn:ngsi-ld:Battery:battery-001",
+    "urn:ngsi-ld:SpaceHeater:spaceheater-001",
+    "urn:ngsi-ld:Vehicle:vehicle-001",
+    "urn:ngsi-ld:EVChargingStation:charger-001"
+  ],
+
+  "aggregatesConsumption": "urn:ngsi-ld:Consumption:community-consumption-001",
+  "aggregatesProduction": "urn:ngsi-ld:GreenEnergyMeasurement:community-production-001",
+  "usesWeatherForecast": "urn:ngsi-ld:Weather:weather-001"
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://smart-data-models.github.io/dataModel.EnergyCommunity/context.jsonld",
+    "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyCommunity/context.jsonld",
     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
   ],
   "id": "urn:ngsi-ld:EnergyCommunity:community-001",

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example.jsonld.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/examples/example.jsonld.json
@@ -1,0 +1,48 @@
+{
+  "@context": [
+    "https://smart-data-models.github.io/dataModel.EnergyCommunity/context.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+  ],
+  "id": "urn:ngsi-ld:EnergyCommunity:community-001",
+  "type": "EnergyCommunity",
+
+  "name": "Göteborg Renewable Energy Community",
+
+  "description": "Local energy community enabling shared photovoltaic generation, storage, and collective self-consumption.",
+
+  "location": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [11.960, 57.700],
+        [11.990, 57.700],
+        [11.990, 57.720],
+        [11.960, 57.720],
+        [11.960, 57.700]
+      ]
+    ]
+  },
+
+  "communityType": "RenewableEnergyCommunity",
+
+  "regulatoryFramework": "EU Renewable Energy Directive (RED II)",
+
+  "hasMember": [
+    "urn:ngsi-ld:EnergyProsumer:prosumer-001",
+    "urn:ngsi-ld:EnergyProsumer:prosumer-002"
+  ],
+
+  "aggregates": [
+    "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
+    "urn:ngsi-ld:Battery:battery-001",
+    "urn:ngsi-ld:SpaceHeater:spaceheater-001",
+    "urn:ngsi-ld:Vehicle:vehicle-001",
+    "urn:ngsi-ld:EVChargingStation:charger-001"
+  ],
+
+  "aggregatesConsumption": "urn:ngsi-ld:Consumption:community-consumption-001",
+
+  "aggregatesProduction": "urn:ngsi-ld:GreenEnergyMeasurement:community-production-001",
+
+  "usesWeatherForecast": "urn:ngsi-ld:Weather:weather-001"
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/notes.yaml
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/notes.yaml
@@ -1,0 +1,32 @@
+notesHeader:
+  Purpose: >
+    This data model represents an Energy Community as a collective entity enabling
+    shared energy production, consumption, and storage among multiple participants.
+
+notesMiddle:
+  Context: >
+    Energy communities enable collective self-consumption, flexibility services,
+    and local energy markets. This model provides a common representation of the
+    community, its members, and aggregated energy assets.
+
+  Scope: >
+    This model does not define physical energy assets such as photovoltaic systems,
+    batteries, electric vehicles, or chargers. These are referenced via NGSI-LD relationships
+    to existing Smart Data Models.
+
+  Relationships:
+    hasMember: Links to EnergyProsumer entities participating in the community.
+    aggregates: Links to energy assets managed at community level.
+    aggregatesConsumption: Links to aggregated community consumption data.
+    aggregatesProduction: Links to aggregated community production data.
+    usesWeatherForecast: Links to weather forecast entities used for optimization.
+
+notesFooter:
+  Reuse: >
+    Designed for reuse across Smart Energy and Smart Cities applications.
+
+  Compatibility: >
+    Fully compatible with NGSI-LD and Smart Data Models guidelines.
+
+  Status: >
+    Incubated in Smart Data Models repository.

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/schema.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schemaVersion": "0.0.1",
+  "$id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyCommunity/schema.json",
+  "title": "Smart Data Models - EnergyCommunity",
+  "description": "A collective entity representing an energy community enabling shared production, consumption, and storage of energy among its members.",
+  "type": "object",
+
+  "allOf": [
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
+    },
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons"
+    },
+    {
+      "properties": {
+
+        "type": {
+          "type": "string",
+          "enum": ["EnergyCommunity"],
+          "description": "NGSI-LD entity type. It must be EnergyCommunity."
+        },
+
+        "communityType": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Property",
+          "description": "Type of energy community (e.g., Renewable Energy Community, Citizen Energy Community)."
+        },
+
+        "regulatoryFramework": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Property",
+          "description": "Regulatory or legal framework governing the energy community."
+        },
+
+        "hasMember": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Energy prosumers participating in the energy community."
+        },
+
+        "aggregates": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Energy assets aggregated, owned, or managed at community level."
+        },
+
+        "aggregatesConsumption": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Aggregated energy consumption of the energy community."
+        },
+
+        "aggregatesProduction": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Aggregated energy production of the energy community."
+        },
+
+        "usesWeatherForecast": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Weather forecast entity used by the energy community."
+        }
+      }
+    }
+  ],
+
+  "required": ["id", "type"]
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyCommunity/schema.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyCommunity/schema.json
@@ -23,23 +23,29 @@
         },
 
         "communityType": {
-          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Property",
+          "type": "string",
           "description": "Type of energy community (e.g., Renewable Energy Community, Citizen Energy Community)."
         },
 
         "regulatoryFramework": {
-          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Property",
+          "type": "string",
           "description": "Regulatory or legal framework governing the energy community."
         },
 
         "hasMember": {
-          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
-          "description": "Energy prosumers participating in the energy community."
+          "type": "array",
+          "description": "Energy prosumers participating in the energy community.",
+          "items": {
+            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship"
+          }
         },
 
         "aggregates": {
-          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
-          "description": "Energy assets aggregated, owned, or managed at community level."
+          "type": "array",
+          "description": "Energy assets aggregated, owned, or managed at community level.",
+          "items": {
+            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship"
+          }
         },
 
         "aggregatesConsumption": {

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/context.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/context.jsonld
@@ -4,13 +4,20 @@
     "https://smart-data-models.github.io/data-models/context.jsonld",
 
     {
-      "EnergyProsumer": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer",
+      "@vocab": "https://smart-data-models.github.io/dataModel.EnergyCommunity/",
 
-      "roleType": "https://smart-data-models.github.io/dataModel.EnergyCommunity/roleType",
-      "timezone": "https://smart-data-models.github.io/dataModel.EnergyCommunity/timezone",
-      "contractedPower": "https://smart-data-models.github.io/dataModel.EnergyCommunity/contractedPower",
-      "totalEnergyImported": "https://smart-data-models.github.io/dataModel.EnergyCommunity/totalEnergyImported",
-      "totalEnergyExported": "https://smart-data-models.github.io/dataModel.EnergyCommunity/totalEnergyExported",
+      "EnergyProsumer": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer",
+        "@type": "@id"
+      },
+
+      "roleType": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/roleType"
+      },
+
+      "timezone": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/timezone"
+      },
 
       "memberOf": {
         "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/memberOf",

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/context.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/context.jsonld
@@ -7,8 +7,7 @@
       "@vocab": "https://smart-data-models.github.io/dataModel.EnergyCommunity/",
 
       "EnergyProsumer": {
-        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer",
-        "@type": "@id"
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer"
       },
 
       "roleType": {
@@ -17,6 +16,18 @@
 
       "timezone": {
         "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/timezone"
+      },
+
+      "contractedPower": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/contractedPower"
+      },
+
+      "totalEnergyImported": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/totalEnergyImported"
+      },
+
+      "totalEnergyExported": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/totalEnergyExported"
       },
 
       "memberOf": {

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/context.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/context.jsonld
@@ -1,0 +1,41 @@
+{
+  "@context": [
+    "https://schema.lab.fiware.org/ld/context",
+    "https://smart-data-models.github.io/data-models/context.jsonld",
+
+    {
+      "EnergyProsumer": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer",
+
+      "roleType": "https://smart-data-models.github.io/dataModel.EnergyCommunity/roleType",
+      "timezone": "https://smart-data-models.github.io/dataModel.EnergyCommunity/timezone",
+      "contractedPower": "https://smart-data-models.github.io/dataModel.EnergyCommunity/contractedPower",
+      "totalEnergyImported": "https://smart-data-models.github.io/dataModel.EnergyCommunity/totalEnergyImported",
+      "totalEnergyExported": "https://smart-data-models.github.io/dataModel.EnergyCommunity/totalEnergyExported",
+
+      "memberOf": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/memberOf",
+        "@type": "@id"
+      },
+
+      "represents": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/represents",
+        "@type": "@id"
+      },
+
+      "controls": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/controls",
+        "@type": "@id"
+      },
+
+      "consumes": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/consumes",
+        "@type": "@id"
+      },
+
+      "produces": {
+        "@id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/produces",
+        "@type": "@id"
+      }
+    }
+  ]
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example-normalized.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example-normalized.json
@@ -1,0 +1,82 @@
+{
+  "id": "urn:ngsi-ld:EnergyProsumer:prosumer-001",
+  "type": "EnergyProsumer",
+
+  "name": {
+    "type": "Property",
+    "value": "Household Prosumer 001"
+  },
+
+  "description": {
+    "type": "Property",
+    "value": "Residential prosumer participating in a local energy community"
+  },
+
+  "roleType": {
+    "type": "Property",
+    "value": "prosumer"
+  },
+
+  "timezone": {
+    "type": "Property",
+    "value": "Europe/Stockholm"
+  },
+
+  "location": {
+    "type": "GeoProperty",
+    "value": {
+      "type": "Point",
+      "coordinates": [11.9746, 57.7089]
+    }
+  },
+
+  "contractedPower": {
+    "type": "Property",
+    "value": 10
+  },
+
+  "totalEnergyImported": {
+    "type": "Property",
+    "value": 4200
+  },
+
+  "totalEnergyExported": {
+    "type": "Property",
+    "value": 1800
+  },
+
+  "memberOf": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:EnergyCommunity:community-001"
+  },
+
+  "represents": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Person:person-001"
+  },
+
+  "controls": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
+      "urn:ngsi-ld:Battery:battery-001",
+      "urn:ngsi-ld:SpaceHeater:spaceheater-001",
+      "urn:ngsi-ld:Vehicle:vehicle-001",
+      "urn:ngsi-ld:EVChargingStation:charger-001"
+    ]
+  },
+
+  "consumes": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:Consumption:consumption-001"
+    ]
+  },
+
+  "produces": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:GreenEnergyMeasurement:production-001"
+    ]
+  }
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example-normalized.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example-normalized.json
@@ -55,28 +55,40 @@
     "object": "urn:ngsi-ld:Person:person-001"
   },
 
-  "controls": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
-      "urn:ngsi-ld:Battery:battery-001",
-      "urn:ngsi-ld:SpaceHeater:spaceheater-001",
-      "urn:ngsi-ld:Vehicle:vehicle-001",
-      "urn:ngsi-ld:EVChargingStation:charger-001"
-    ]
-  },
+  "controls": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:PhotovoltaicDevice:pv-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Battery:battery-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:SpaceHeater:spaceheater-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Vehicle:vehicle-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:EVChargingStation:charger-001"
+    }
+  ],
 
-  "consumes": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:Consumption:consumption-001"
-    ]
-  },
+  "consumes": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Consumption:consumption-001"
+    }
+  ],
 
-  "produces": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:GreenEnergyMeasurement:production-001"
-    ]
-  }
+  "produces": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:GreenEnergyMeasurement:production-001"
+    }
+  ]
 }

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example-normalized.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example-normalized.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://smart-data-models.github.io/dataModel.EnergyProsumer/context.jsonld",
+    "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer/context.jsonld",
     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
   ],
 
@@ -60,28 +60,40 @@
     "object": "urn:ngsi-ld:Person:person-001"
   },
 
-  "controls": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
-      "urn:ngsi-ld:Battery:battery-001",
-      "urn:ngsi-ld:SpaceHeater:spaceheater-001",
-      "urn:ngsi-ld:Vehicle:vehicle-001",
-      "urn:ngsi-ld:EVChargingStation:charger-001"
-    ]
-  },
+  "controls": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:PhotovoltaicDevice:pv-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Battery:battery-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:SpaceHeater:spaceheater-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Vehicle:vehicle-001"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:EVChargingStation:charger-001"
+    }
+  ],
 
-  "consumes": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:Consumption:consumption-001"
-    ]
-  },
+  "consumes": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Consumption:consumption-001"
+    }
+  ],
 
-  "produces": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:GreenEnergyMeasurement:production-001"
-    ]
-  }
+  "produces": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:GreenEnergyMeasurement:production-001"
+    }
+  ]
 }

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example-normalized.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example-normalized.jsonld
@@ -1,0 +1,87 @@
+{
+  "@context": [
+    "https://smart-data-models.github.io/dataModel.EnergyProsumer/context.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+  ],
+
+  "id": "urn:ngsi-ld:EnergyProsumer:prosumer-001",
+  "type": "EnergyProsumer",
+
+  "name": {
+    "type": "Property",
+    "value": "Household Prosumer 001"
+  },
+
+  "description": {
+    "type": "Property",
+    "value": "Residential prosumer participating in a local energy community"
+  },
+
+  "roleType": {
+    "type": "Property",
+    "value": "prosumer"
+  },
+
+  "timezone": {
+    "type": "Property",
+    "value": "Europe/Stockholm"
+  },
+
+  "location": {
+    "type": "GeoProperty",
+    "value": {
+      "type": "Point",
+      "coordinates": [11.9746, 57.7089]
+    }
+  },
+
+  "contractedPower": {
+    "type": "Property",
+    "value": 10
+  },
+
+  "totalEnergyImported": {
+    "type": "Property",
+    "value": 4200
+  },
+
+  "totalEnergyExported": {
+    "type": "Property",
+    "value": 1800
+  },
+
+  "memberOf": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:EnergyCommunity:community-001"
+  },
+
+  "represents": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Person:person-001"
+  },
+
+  "controls": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
+      "urn:ngsi-ld:Battery:battery-001",
+      "urn:ngsi-ld:SpaceHeater:spaceheater-001",
+      "urn:ngsi-ld:Vehicle:vehicle-001",
+      "urn:ngsi-ld:EVChargingStation:charger-001"
+    ]
+  },
+
+  "consumes": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:Consumption:consumption-001"
+    ]
+  },
+
+  "produces": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:GreenEnergyMeasurement:production-001"
+    ]
+  }
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example.json
@@ -1,0 +1,38 @@
+{
+  "id": "urn:ngsi-ld:EnergyProsumer:prosumer-001",
+  "type": "EnergyProsumer",
+
+  "name": "Household Prosumer 001",
+  "description": "Residential prosumer participating in a local energy community",
+  "roleType": "prosumer",
+  "timezone": "Europe/Stockholm",
+
+  "location": {
+    "type": "Point",
+    "coordinates": [11.9746, 57.7089]
+  },
+
+  "contractedPower": 10,
+  "totalEnergyImported": 4200,
+  "totalEnergyExported": 1800,
+
+  "memberOf": "urn:ngsi-ld:EnergyCommunity:community-001",
+
+  "represents": "urn:ngsi-ld:Person:person-001",
+
+  "controls": [
+    "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
+    "urn:ngsi-ld:Battery:battery-001",
+    "urn:ngsi-ld:SpaceHeater:spaceheater-001",
+    "urn:ngsi-ld:Vehicle:vehicle-001",
+    "urn:ngsi-ld:EVChargingStation:charger-001"
+  ],
+
+  "consumes": [
+    "urn:ngsi-ld:Consumption:consumption-001"
+  ],
+
+  "produces": [
+    "urn:ngsi-ld:GreenEnergyMeasurement:production-001"
+  ]
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://smart-data-models.github.io/dataModel.EnergyProsumer/context.jsonld",
+    "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer/context.jsonld",
     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
   ],
 

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example.jsonld
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/examples/example.jsonld
@@ -1,0 +1,43 @@
+{
+  "@context": [
+    "https://smart-data-models.github.io/dataModel.EnergyProsumer/context.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+  ],
+
+  "id": "urn:ngsi-ld:EnergyProsumer:prosumer-001",
+  "type": "EnergyProsumer",
+
+  "name": "Household Prosumer 001",
+  "description": "Residential prosumer participating in a local energy community",
+  "roleType": "prosumer",
+  "timezone": "Europe/Stockholm",
+
+  "location": {
+    "type": "Point",
+    "coordinates": [11.9746, 57.7089]
+  },
+
+  "contractedPower": 10,
+  "totalEnergyImported": 4200,
+  "totalEnergyExported": 1800,
+
+  "memberOf": "urn:ngsi-ld:EnergyCommunity:community-001",
+
+  "represents": "urn:ngsi-ld:Person:person-001",
+
+  "controls": [
+    "urn:ngsi-ld:PhotovoltaicDevice:pv-001",
+    "urn:ngsi-ld:Battery:battery-001",
+    "urn:ngsi-ld:SpaceHeater:spaceheater-001",
+    "urn:ngsi-ld:Vehicle:vehicle-001",
+    "urn:ngsi-ld:EVChargingStation:charger-001"
+  ],
+
+  "consumes": [
+    "urn:ngsi-ld:Consumption:consumption-001"
+  ],
+
+  "produces": [
+    "urn:ngsi-ld:GreenEnergyMeasurement:production-001"
+  ]
+}

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/notes.yaml
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/notes.yaml
@@ -1,0 +1,34 @@
+notesHeader:
+  Purpose: >
+    This data model represents an Energy Prosumer, a role played by an
+    individual or organization that both consumes and produces energy
+    within an energy community.
+
+notesMiddle:
+  Context: >
+    Participants in energy communities often act simultaneously as consumers
+    and producers of energy. This role cannot be fully represented using
+    generic Person or Organization models alone.
+
+  Scope: >
+    This model defines the energy participation role and its relationships
+    to energy assets, consumption, and production. It does not model Person
+    or Organization entities directly.
+
+  Relationships:
+    represents: Links the prosumer role to the underlying Person or Organization.
+    memberOf: Links the prosumer to an EnergyCommunity.
+    controls: Links to energy assets controlled by the prosumer.
+    consumes: Links to energy consumption data associated with the prosumer.
+    produces: Links to energy production data associated with the prosumer.
+
+notesFooter:
+  DesignRationale: >
+    Explicit modeling of prosumer roles enables flexible representation across
+    different energy community configurations.
+
+  Standards: >
+    Fully compliant with NGSI-LD and Smart Data Models guidelines.
+
+  Status: >
+    Incubated in Smart Data Models repository.

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/schema.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/schema.json
@@ -1,4 +1,4 @@
-{{
+{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$schemaVersion": "0.0.1",
   "$id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer/schema.json",

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/schema.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/schema.json
@@ -1,4 +1,4 @@
-{
+{{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$schemaVersion": "0.0.1",
   "$id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer/schema.json",
@@ -59,18 +59,27 @@
         },
 
         "controls": {
-          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
-          "description": "Energy assets controlled by the prosumer."
+          "type": "array",
+          "description": "Energy assets controlled by the prosumer.",
+          "items": {
+            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship"
+          }
         },
 
         "consumes": {
-          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
-          "description": "Energy consumption entities associated with the prosumer."
+          "type": "array",
+          "description": "Energy consumption entities associated with the prosumer.",
+          "items": {
+            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship"
+          }
         },
 
         "produces": {
-          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
-          "description": "Energy production entities associated with the prosumer."
+          "type": "array",
+          "description": "Energy production entities associated with the prosumer.",
+          "items": {
+            "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship"
+          }
         }
       }
     }

--- a/SMARTENERGY/EnergyCommunity/EnergyProsumer/schema.json
+++ b/SMARTENERGY/EnergyCommunity/EnergyProsumer/schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schemaVersion": "0.0.1",
+  "$id": "https://smart-data-models.github.io/dataModel.EnergyCommunity/EnergyProsumer/schema.json",
+  "title": "Smart Data Models - EnergyProsumer",
+  "description": "A role played by an individual or organization that both consumes and produces energy within an energy community.",
+  "type": "object",
+
+  "allOf": [
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
+    },
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons"
+    },
+    {
+      "properties": {
+
+        "type": {
+          "type": "string",
+          "enum": ["EnergyProsumer"],
+          "description": "NGSI entity type. It must be EnergyProsumer."
+        },
+
+        "roleType": {
+          "type": "string",
+          "enum": ["consumer", "producer", "prosumer"],
+          "description": "Energy participation role of the entity."
+        },
+
+        "timezone": {
+          "type": "string",
+          "description": "Timezone of the prosumer location (IANA TZ database)."
+        },
+
+        "contractedPower": {
+          "type": "number",
+          "description": "Contracted active power for the prosumer."
+        },
+
+        "totalEnergyImported": {
+          "type": "number",
+          "description": "Total cumulative imported energy."
+        },
+
+        "totalEnergyExported": {
+          "type": "number",
+          "description": "Total cumulative exported energy."
+        },
+
+        "memberOf": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Energy community in which the prosumer participates."
+        },
+
+        "represents": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Person or organization playing the energy prosumer role."
+        },
+
+        "controls": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Energy assets controlled by the prosumer."
+        },
+
+        "consumes": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Energy consumption entities associated with the prosumer."
+        },
+
+        "produces": {
+          "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Relationship",
+          "description": "Energy production entities associated with the prosumer."
+        }
+      }
+    }
+  ],
+
+  "required": ["id", "type"]
+}

--- a/SMARTENERGY/EnergyCommunity/notes.yaml
+++ b/SMARTENERGY/EnergyCommunity/notes.yaml
@@ -1,0 +1,36 @@
+notesHeader:
+  Purpose: >
+    This repository/subject groups data models related to energy communities and
+    collective energy participation. It defines a set of models that support
+    community-level organization, governance, and participant roles enabling
+    shared energy production, consumption, and storage.
+
+notesMiddle:
+  Rationale: >
+    Energy communities represent a distinct conceptual layer that enables
+    collective self-consumption, energy sharing, and coordination among
+    multiple participants. This layer complements individual energy assets
+    and consumer-level models.
+
+  Scope: >
+    This collection focuses on community-level entities and participation roles.
+    Physical energy assets such as photovoltaic systems, batteries, electric
+    vehicles, chargers, or heating devices are not defined here, but are
+    referenced through existing Smart Energy data models.
+
+  IncludedDataModels:
+    EnergyCommunity: >
+      Represents the collective entity enabling energy sharing, aggregation,
+      and governance at community level.
+
+    EnergyProsumer: >
+      Represents the role of participants that both consume and produce energy
+      within an energy community.
+
+notesFooter:
+  Domains: >
+    This collection belongs primarily to the Smart Energy domain and may also
+    be reused in Smart Cities, Smart Buildings, and energy market applications.
+
+  Status: >
+    Incubated in the Smart Data Models repository.


### PR DESCRIPTION
Description
This pull request introduces a new EnergyCommunity subject under the Smart Energy domain, addressing the need to model collective self‑consumption and energy sharing scenarios.
Two new data models are proposed:


EnergyCommunity
Represents a collective entity enabling shared production, consumption, and storage of energy. The model focuses on community‑level aggregation, governance, and relationships, without redefining physical energy assets.


EnergyProsumer
Represents a role played by a Person or Organization that both consumes and produces energy within an energy community.


The proposed models:

Reuse existing Smart Data Models for physical assets (PhotovoltaicDevice, Battery, EV, EVChargingStation, EnergyConsumption, EnergyProduction, WeatherForecast) through NGSI‑LD relationships.
Follow Smart Data Models guidelines and NGSI‑LD specifications.
Use GSMA‑Commons and Location‑Commons for shared attributes.
Are intended to be generic, reusable, and compatible with different regulatory frameworks.

The contribution is proposed for inclusion in the incubated repository under the Smart Energy domain.

Contents

EnergyCommunity data model
EnergyProsumer data model
NGSI‑LD context files
Schema files
Validated JSON / JSON‑LD examples
Documentation notes (notes.yaml)
Adopters and Contributors files

Feedback and review are welcome.